### PR TITLE
feat/deploy_settings

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,5 +1,5 @@
 # Django settings
-DJANGO_SECRET_KEY='django-insecure-t(z@l$u7n!%%c*1xqlitk6@=+c7tew97oqa(dng5ijrbt29*q$'
+DJANGO_SECRET_KEY=yoursecretkey
 DEBUG=True
 DJANGO_ALLOWED_HOSTS=127.0.0.1,localhost,158.160.142.238
 CSRF_TRUSTED_ORIGINS=http://127.0.0.1:8080,http://localhost:8080,http://158.160.142.238/

--- a/.env-example-local
+++ b/.env-example-local
@@ -1,5 +1,5 @@
 # Django settings
-DJANGO_SECRET_KEY='django-insecure-t(z@l$u7n!%%c*1xqlitk6@=+c7tew97oqa(dng5ijrbt29*q$'
+DJANGO_SECRET_KEY=yoursecretkey
 DEBUG=True
 DJANGO_ALLOWED_HOSTS=127.0.0.1,localhost
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-alpine
+FROM python:3.11-slim as base
 
 RUN python3 -m pip install --upgrade pip
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -16,7 +16,7 @@ DEBUG = os.getenv("DEBUG", "False") == "True"
 
 ALLOWED_HOSTS = os.getenv(
     "DJANGO_ALLOWED_HOSTS", "localhost 127.0.0.1 158.160.142.238"
-).split(" ")
+).split(",")
 CSRF_TRUSTED_ORIGINS = os.environ["CSRF_TRUSTED_ORIGINS"].split(",")
 CORS_ALLOWED_ORIGINS = os.getenv("CORS_ALLOWED_ORIGINS", "").split(" ")
 
@@ -121,10 +121,10 @@ USE_I18N = True
 USE_TZ = True
 
 
-MEDIA_URL = "media/"
+MEDIA_URL = "/backend_media/"
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 
-STATIC_URL = "static/"
+STATIC_URL = "/backend_static/"
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -x
-python manage.py migrate
-python manage.py collectstatic
-cp -rg /app/static/ . /backend_static/static/
+python manage.py migrate --noinput
+python manage.py collectstatic --no-input --clear
+cp -r /app/static/. /backend_static/
 gunicorn --bind 0.0.0.0:8000 config.wsgi

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -15,6 +15,13 @@ server {
     proxy_pass http://backend:8000/admin/;
   }
 
+  location /swagger/ {
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-Server $host;
+    proxy_pass http://backend:8000/swagger/;
+  }
+
   location /backend_static/ {
     alias /backend_static/;
   }


### PR DESCRIPTION
Убрал в примерах .env  наш ключ. Не устанавливался catboost с numpy из докер-образа  python3.11:alpine, изменил на slim и зависимости прошли. Поправил пути к media,static в settings.py. Поправил entrypoint.sh и добавил в nginx обработчик путь к сваггеру. Вроде бы ничего больше не забыл.
